### PR TITLE
Add unicode character support to DB

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/DatabaseUpdater.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/DatabaseUpdater.java
@@ -101,22 +101,22 @@ public class DatabaseUpdater {
 		Connection conn = databaseManager.getSQLConnection();
 		try (Statement st = conn.createStatement()) {
 			st.addBatch("CREATE TABLE IF NOT EXISTS " + databaseManager.getPrefix()
-					+ "achievements (playername char(36),achievement varchar(64),date TIMESTAMP,PRIMARY KEY (playername, achievement))");
+					+ "achievements (playername char(36),achievement varchar(64),date TIMESTAMP,PRIMARY KEY (playername, achievement)) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci");
 
 			for (MultipleAchievements category : MultipleAchievements.values()) {
 				st.addBatch("CREATE TABLE IF NOT EXISTS " + databaseManager.getPrefix() + category.toDBName()
 						+ " (playername char(36)," + category.toSubcategoryDBName() + " varchar(" + size + "),"
-						+ category.toDBName() + " INT,PRIMARY KEY(playername, " + category.toSubcategoryDBName() + "))");
+						+ category.toDBName() + " INT,PRIMARY KEY(playername, " + category.toSubcategoryDBName() + ")) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci");
 			}
 
 			for (NormalAchievements category : NormalAchievements.values()) {
 				if (category == NormalAchievements.CONNECTIONS) {
 					st.addBatch("CREATE TABLE IF NOT EXISTS " + databaseManager.getPrefix() + category.toDBName()
 							+ " (playername char(36)," + category.toDBName()
-							+ " INT,date varchar(10),PRIMARY KEY (playername))");
+							+ " INT,date varchar(10),PRIMARY KEY (playername)) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci");
 				} else {
 					st.addBatch("CREATE TABLE IF NOT EXISTS " + databaseManager.getPrefix() + category.toDBName()
-							+ " (playername char(36)," + category.toDBName() + " BIGINT,PRIMARY KEY (playername))");
+							+ " (playername char(36)," + category.toDBName() + " BIGINT,PRIMARY KEY (playername)) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci");
 				}
 			}
 			st.executeBatch();


### PR DESCRIPTION
By default mysql (and probably other DB engines too) use a weird character set, `latin1_swedish_ci` in MySQL's case [why?](https://stackoverflow.com/questions/6769901/why-is-mysqls-default-collation-latin1-swedish-ci)

Using the relevant clauses in each `CREATE TABLE` statement and the recommended options in the config, unicode/utf8 support is achieved.