### PR TITLE
fix npe related to missing configuration sections

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -272,11 +272,10 @@ public class ConfigurationParser {
 
 		// Enumerate Commands achievements.
 		if (!disabledCategories.contains(CommandAchievements.COMMANDS)) {
-			Set<String> commands = mainConfig.getConfigurationSection(CommandAchievements.COMMANDS.toString())
-					.getKeys(false);
-			if (commands.isEmpty()) {
+			if (!mainConfig.isConfigurationSection(CommandAchievements.COMMANDS.toString())) {
 				disabledCategories.add(CommandAchievements.COMMANDS);
 			} else {
+				Set<String> commands = mainConfig.getConfigurationSection(CommandAchievements.COMMANDS.toString()).getKeys(false);
 				for (String command : commands) {
 					parseAchievement(CommandAchievements.COMMANDS, command, -1L);
 				}
@@ -286,7 +285,7 @@ public class ConfigurationParser {
 		// Enumerate the normal achievements.
 		for (NormalAchievements category : NormalAchievements.values()) {
 			if (!disabledCategories.contains(category)) {
-				if (mainConfig.getConfigurationSection(category.toString()).getKeys(false).isEmpty()) {
+				if (!mainConfig.isConfigurationSection(category.toString())) {
 					disabledCategories.add(category);
 					continue;
 				}
@@ -299,11 +298,12 @@ public class ConfigurationParser {
 		// Enumerate the achievements with multiple categories.
 		for (MultipleAchievements category : MultipleAchievements.values()) {
 			if (!disabledCategories.contains(category)) {
-				Set<String> subcategories = mainConfig.getConfigurationSection(category.toString()).getKeys(false);
-				if (subcategories.isEmpty()) {
+				if (!mainConfig.isConfigurationSection(category.toString())) {
 					disabledCategories.add(category);
 					continue;
 				}
+
+				Set<String> subcategories = mainConfig.getConfigurationSection(category.toString()).getKeys(false);
 				for (String subcategory : subcategories) {
 					for (long threshold : getSortedThresholds(category + "." + subcategory)) {
 						parseAchievement(category, subcategory, threshold);

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -311,12 +311,12 @@ public class ConfigurationParser {
 		// Enumerate the achievements with multiple categories.
 		for (MultipleAchievements category : MultipleAchievements.values()) {
 			if (!disabledCategories.contains(category)) {
-				if (getSectionKeys(category.toString()).isEmpty()) {
+				Set<String> subcategories = getSectionKeys(category.toString());
+				if (subcategories.isEmpty()) {
 					disabledCategories.add(category);
 					continue;
 				}
 
-				Set<String> subcategories = mainConfig.getConfigurationSection(category.toString()).getKeys(false);
 				for (String subcategory : subcategories) {
 					for (long threshold : getSortedThresholds(category + "." + subcategory)) {
 						parseAchievement(category, subcategory, threshold);

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -275,7 +275,8 @@ public class ConfigurationParser {
 			if (!mainConfig.isConfigurationSection(CommandAchievements.COMMANDS.toString())) {
 				disabledCategories.add(CommandAchievements.COMMANDS);
 			} else {
-				Set<String> commands = mainConfig.getConfigurationSection(CommandAchievements.COMMANDS.toString()).getKeys(false);
+				Set<String> commands = mainConfig.getConfigurationSection(CommandAchievements.COMMANDS.toString())
+						.getKeys(false);
 				for (String command : commands) {
 					parseAchievement(CommandAchievements.COMMANDS, command, -1L);
 				}

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -89,6 +90,18 @@ public class ConfigurationParser {
 		parseDisabledCategories();
 		parseAchievements();
 		logLoadingMessages();
+	}
+
+	/**
+	 * Reterive keys associated with the configuration section at the given path
+	 *
+	 * @param path
+	 * @return A set containing the keys
+	 */
+	private Set<String> getSectionKeys(String path) {
+		return this.mainConfig.isConfigurationSection(path)
+				? this.mainConfig.getConfigurationSection(path).getKeys(false)
+				: Collections.emptySet();
 	}
 
 	/**
@@ -272,11 +285,10 @@ public class ConfigurationParser {
 
 		// Enumerate Commands achievements.
 		if (!disabledCategories.contains(CommandAchievements.COMMANDS)) {
-			if (!mainConfig.isConfigurationSection(CommandAchievements.COMMANDS.toString())) {
+			Set<String> commands = getSectionKeys(CommandAchievements.COMMANDS.toString());
+			if (commands.isEmpty()) {
 				disabledCategories.add(CommandAchievements.COMMANDS);
 			} else {
-				Set<String> commands = mainConfig.getConfigurationSection(CommandAchievements.COMMANDS.toString())
-						.getKeys(false);
 				for (String command : commands) {
 					parseAchievement(CommandAchievements.COMMANDS, command, -1L);
 				}
@@ -286,7 +298,7 @@ public class ConfigurationParser {
 		// Enumerate the normal achievements.
 		for (NormalAchievements category : NormalAchievements.values()) {
 			if (!disabledCategories.contains(category)) {
-				if (!mainConfig.isConfigurationSection(category.toString())) {
+				if (getSectionKeys(category.toString()).isEmpty()) {
 					disabledCategories.add(category);
 					continue;
 				}
@@ -299,7 +311,7 @@ public class ConfigurationParser {
 		// Enumerate the achievements with multiple categories.
 		for (MultipleAchievements category : MultipleAchievements.values()) {
 			if (!disabledCategories.contains(category)) {
-				if (!mainConfig.isConfigurationSection(category.toString())) {
+				if (getSectionKeys(category.toString()).isEmpty()) {
 					disabledCategories.add(category);
 					continue;
 				}


### PR DESCRIPTION
Hey! 👋 I ran into an issue after updating AACH from 6.7.2 to 7.0.0 (7.0.1 produced the same error).

```[08:52:21] [Server thread/ERROR]: Error occurred while enabling AdvancedAchievements v7.0.1 (Is it up to date?)
java.lang.NullPointerException: null
	at com.hm.achievement.config.ConfigurationParser.parseAchievements(ConfigurationParser.java:289) ~[?:?]
	at com.hm.achievement.config.ConfigurationParser.loadAndParseConfiguration(ConfigurationParser.java:90) ~[?:?]
	at com.hm.achievement.lifecycle.PluginLoader.loadAdvancedAchievements(PluginLoader.java:142) ~[?:?]
	at com.hm.achievement.AdvancedAchievements.onEnable(AdvancedAchievements.java:49) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263) ~[patched_1.16.5.jar:git-Paper-506]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:380) ~[patched_1.16.5.jar:git-Paper-506]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:483) ~[patched_1.16.5.jar:git-Paper-506]
	at org.bukkit.craftbukkit.v1_16_R3.CraftServer.enablePlugin(CraftServer.java:501) ~[patched_1.16.5.jar:git-Paper-506]
	at org.bukkit.craftbukkit.v1_16_R3.CraftServer.enablePlugins(CraftServer.java:415) ~[patched_1.16.5.jar:git-Paper-506]
	at net.minecraft.server.v1_16_R3.MinecraftServer.loadWorld(MinecraftServer.java:466) ~[patched_1.16.5.jar:git-Paper-506]
	at net.minecraft.server.v1_16_R3.DedicatedServer.init(DedicatedServer.java:239) ~[patched_1.16.5.jar:git-Paper-506]
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:941) ~[patched_1.16.5.jar:git-Paper-506]
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:175) ~[patched_1.16.5.jar:git-Paper-506]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

After forking the project and adding debug messages, it turned out that this is related to missing configuration sections. Maybe `YamlConfiguration#getConfigurationSection` behaves differently compared to older spigot/paper versions, but I haven't touched the config in a while, so this error came to me as a not so pleasent surprise. 

The problem is that every achievement category has been disabled like this:
```yaml
Category: []
```
I guess this isn't the proper way of doing it, but I really don't want to reconfigure the whole thing... Anyways, my solution to this is to replace `getConfigurationSection("key").getKeys(false).isEmpty()` to `isConfigurationSection("key")`. It should do the same thing but without producing errors. I have tested it on paper 1.16.5 and on craftbukkit 1.7.2 to see if this function even exists on such an old version, but I haven't encountered any issues so far. *(Altough I discovered something else on 1.7.2, I'll open a PR for that as well, if you don't mind :) )*

